### PR TITLE
Replace array syntax and require PHPUnit ^6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "vlucas/phpdotenv": "^2.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^6.5",
         "mockery/mockery": "^1.2"
     },
     "license": "MIT",

--- a/tests/VirtualCardTest.php
+++ b/tests/VirtualCardTest.php
@@ -21,7 +21,7 @@ class VirtualCardTest extends TestCase
 {
     public function test_card_is_created_when_payload_is_posted()
     {
-        $array = array(
+        $array = [
             "secret_key"=>"FLWSECK-c481f575f255c9344dc128b12e5146c8-X",
             "currency"=> "NGN",
             "amount"=>"200",
@@ -31,11 +31,11 @@ class VirtualCardTest extends TestCase
             "billing_state"=>"NEW LANGE",
             "billing_postal_code"=> "293094",
             "billing_country"=> "US"
-        );
+        ];
         $double = Mockery::mock(virtualCardAPI::class);
         $virtualCard = new VirtualCard();
         $result = $virtualCard->create($array);
-        $this->assertInstanceOf($double->shouldReceive('create')->with($array)->andReturn(array()), []);
+        $this->assertInstanceOf($double->shouldReceive('create')->with($array)->andReturn([]), []);
 
     }
 


### PR DESCRIPTION
#### Types of changes
- [X] Improvements.
- Adding the `PHPUnit:^6.5` version for requiring `php-7.0` version at least.
- Since this SDK requires `php-7.0` version at least, using the short array syntax with array syntax.